### PR TITLE
Fix Wrangler installation in deploy workflow

### DIFF
--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -1,9 +1,6 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - main
   workflow_run:
     workflows: ["CI"]
     types:
@@ -16,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     # Only deploy if CI workflow succeeded
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_WORKER_API_TOKEN }}


### PR DESCRIPTION
- Upgrade cloudflare/wrangler-action from v3 to v4 to fix installation issues
- Remove push trigger to prevent Deploy workflow from running before CI completes
- Simplify conditional to only check workflow_run success status
- Deploy workflow now only runs after CI workflow completes successfully