### PR TITLE
Fix Wrangler deploy failure

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,8 @@ export type Config = {
 // Load configuration
 const loadConfig = (): Config => {
   // If CONFIG_PATH is set, load custom config (Docker with custom config)
-  if (process.env.CONFIG_PATH) {
+  // Note: process is not available in Cloudflare Workers, only in Node.js/Docker environments
+  if (typeof process !== 'undefined' && process.env?.CONFIG_PATH) {
     try {
       const { readFileSync } = require('fs');
       const fileContents = readFileSync(process.env.CONFIG_PATH, 'utf8');


### PR DESCRIPTION
The loadConfig function was accessing process.env.CONFIG_PATH directly, which caused deployment failures in Cloudflare Workers where process is not available. Added typeof check to ensure process exists before accessing it, maintaining CONFIG_PATH functionality for Docker while allowing Workers deployment to succeed with the bundled config.